### PR TITLE
PSR-2 conversion and Composer installation support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "phaxio/phaxio",
+    "type": "library",
+    "description": "The Phaxio API PHP library",
+    "keywords": ["phaxio", "fax"],
+    "homepage": "http://www.phaxio.com/",
+    "license": "MIT",
+    "require": {
+        "php": ">=5.3.0"
+    },
+    "autoload": {
+        "psr-0": { "Phaxio\\": "lib/" }
+    }
+}

--- a/examples/autoload.php
+++ b/examples/autoload.php
@@ -1,0 +1,10 @@
+<?php
+
+/**
+ * Simple autoloader for examples.
+ * Use a proper PSR-0 autoloader implementation in production.
+ */
+function __autoload($class)
+{
+    require __DIR__ . '/../lib/' . str_replace('\\', DIRECTORY_SEPARATOR, $class) . '.php';
+}

--- a/examples/closeBatch.php
+++ b/examples/closeBatch.php
@@ -1,6 +1,9 @@
-<?
+<?php
+
 require_once('phaxio_config.php');
-require_once(dirname(__FILE__) . '/../lib/Phaxio.class.php');
+require_once('autoload.php');
+
+use Phaxio\Phaxio;
 
 //enter a batchId to close
 $batchId = 23;
@@ -8,6 +11,3 @@ $batchId = 23;
 $phaxio = new Phaxio($apiKeys[$apiMode], $apiSecrets[$apiMode], $apiHost);
 $result = $phaxio->closeBatch($batchId);
 var_dump($result);
-
-?>
-

--- a/examples/createBatch.php
+++ b/examples/createBatch.php
@@ -1,6 +1,9 @@
-<?
+<?php
+
 require_once('phaxio_config.php');
-require_once(dirname(__FILE__) . '/../lib/Phaxio.class.php');
+require_once('autoload.php');
+
+use Phaxio\Phaxio;
 
 $phaxio = new Phaxio($apiKeys[$apiMode], $apiSecrets[$apiMode], $apiHost);
 
@@ -10,6 +13,3 @@ for ($i = 1; $i <= 5; $i++){
 }
 
 echo "Your batch has been created for $toNumber.  You can now see it in the Phaxio web UI.  To fire it, see fireBatch.php";
-
-?>
-

--- a/examples/createBatchWithDelay.php
+++ b/examples/createBatchWithDelay.php
@@ -1,6 +1,9 @@
-<?
+<?php
+
 require_once('phaxio_config.php');
-require_once(dirname(__FILE__) . '/../lib/Phaxio.class.php');
+require_once('autoload.php');
+
+use Phaxio\Phaxio;
 
 $phaxio = new Phaxio($apiKeys[$apiMode], $apiSecrets[$apiMode], $apiHost);
 
@@ -26,7 +29,4 @@ for ($i = 1; $i <= 3; $i++){
     echo "Part $i of 3 sent.  Sleeping for 5 seconds...";
     sleep(5);
 }
-echo "Done."
-
-?>
-
+echo "Done.";

--- a/examples/fireBatch.php
+++ b/examples/fireBatch.php
@@ -1,6 +1,9 @@
-<?
+<?php
+
 require_once('phaxio_config.php');
-require_once(dirname(__FILE__) . '/../lib/Phaxio.class.php');
+require_once('autoload.php');
+
+use Phaxio\Phaxio;
 
 //enter a batchId to fire
 $batchId = 0;
@@ -8,6 +11,3 @@ $batchId = 0;
 $phaxio = new Phaxio($apiKeys[$apiMode], $apiSecrets[$apiMode], $apiHost);
 $result = $phaxio->fireBatch($batchId);
 var_dump($result);
-
-?>
-

--- a/examples/phaxio_config.php.temp
+++ b/examples/phaxio_config.php.temp
@@ -1,4 +1,5 @@
-<?
+<?php
+
 $apiKeys['live'] = '';
 $apiSecrets['live'] = '';
 $apiKeys['test'] = '';
@@ -22,4 +23,3 @@ FAX;
 $textData = <<<FAX
 This is text data.
 FAX;
-

--- a/examples/sendHtmlStringData.php
+++ b/examples/sendHtmlStringData.php
@@ -1,10 +1,10 @@
-<?
+<?php
+
 require_once('phaxio_config.php');
-require_once(dirname(__FILE__) . '/../lib/Phaxio.class.php');
+require_once('autoload.php');
+
+use Phaxio\Phaxio;
 
 $phaxio = new Phaxio($apiKeys[$apiMode], $apiSecrets[$apiMode], $apiHost);
 $result = $phaxio->sendFax($toNumber, array(), array('string_data' => $htmlData, 'string_data_type' => 'html'));
 var_dump($result);
-
-?>
-

--- a/examples/sendTextStringDataWithCustomCallback.php
+++ b/examples/sendTextStringDataWithCustomCallback.php
@@ -1,10 +1,10 @@
-<?
+<?php
+
 require_once('phaxio_config.php');
-require_once(dirname(__FILE__) . '/../lib/Phaxio.class.php');
+require_once('autoload.php');
+
+use Phaxio\Phaxio;
 
 $phaxio = new Phaxio($apiKeys[$apiMode], $apiSecrets[$apiMode], $apiHost);
 $result = $phaxio->sendFax($toNumber, array(), array('callback_url' => $customCallback, 'string_data' => $textData, 'string_data_type' => 'text'));
 var_dump($result);
-
-?>
-

--- a/lib/Phaxio/PhaxioException.php
+++ b/lib/Phaxio/PhaxioException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Phaxio;
+
+class PhaxioException extends \Exception
+{
+}

--- a/lib/Phaxio/PhaxioOperationResult.php
+++ b/lib/Phaxio/PhaxioOperationResult.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Phaxio;
+
+class PhaxioOperationResult
+{
+    private $message = null;
+    private $success = false;
+    private $data = null;
+
+    public function __construct($success, $message = null, $data = null)
+    {
+        $this->success = $success;
+        $this->message = $message;
+
+        if ($data != null) {
+            $this->data = $data;
+        }
+    }
+
+    public function succeeded()
+    {
+        return $this->success;
+    }
+
+    public function getData()
+    {
+        return $this->data;
+    }
+
+    public function getMessage()
+    {
+        return $this->message;
+    }
+}


### PR DESCRIPTION
PHP libraries are advised to comply with the [PSR-0 standard](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md) for autoloader interoperability.

Also, the de-facto standard for PHP dependency management is [Composer](http://getcomposer.org/).

This PR moves the Phaxio classes in a `Phaxio` namespace, and makes the code compatible with [PSR-0](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-0.md), [PSR-1](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-1-basic-coding-standard.md) and [PSR-2](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-2-coding-style-guide.md).

It also adds a `composer.json` file for Composer.
You can then [submit the package](https://packagist.org/packages/submit) to Composer (this PR will need to be accepted first).
