### PR TITLE
fixed missing data key error

### DIFF
--- a/lib/Phaxio/Phaxio.php
+++ b/lib/Phaxio/Phaxio.php
@@ -130,8 +130,10 @@ class Phaxio
 
             if (! $result) {
                 $opResult = new PhaxioOperationResult(false, "No data received from service.");
-            } else {
+            } else if($result['success']){
                 $opResult = new PhaxioOperationResult($result['success'], $result['message'], $result['data']);
+            } else {
+                $opResult = new PhaxioOperationResult($result['success'], $result['message']);
             }
 
             return $opResult;


### PR DESCRIPTION
When an error response is set the 'data' key does not appear to be set raising an error.
