### PR TITLE
ATA retrieve endpoint

### DIFF
--- a/examples/listATAs.php
+++ b/examples/listATAs.php
@@ -1,0 +1,9 @@
+<?php
+
+require_once('phaxio_config.php');
+require_once('autoload.php');
+
+$phaxio = new Phaxio($apiKeys[$apiMode], $apiSecrets[$apiMode], $apiHost);
+
+$result = $phaxio->listATAs();
+var_dump($result);

--- a/lib/Phaxio.php
+++ b/lib/Phaxio.php
@@ -5,7 +5,7 @@ class Phaxio
     private $debug = false;
     private $api_key = null;
     private $api_secret = null;
-    private $host = "https://api.phaxio.com/v2/";
+    private $host = "https://api.phaxio.com/v2.1/";
 
     public function __construct($api_key = null, $api_secret = null, $host = null)
     {
@@ -40,6 +40,10 @@ class Phaxio
         return new Phaxio\Account($this);
     }
 
+    public function atas() {
+        return new Phaxio\ATAs($this);
+    }
+
     # Convenience methods
 
     public function sendFax($params) {
@@ -50,12 +54,26 @@ class Phaxio
         return $this->faxes()->init($id);
     }
 
-    public function retriveFaxFile($id, $params = array()) {
+    public function retrieveFaxFile($id, $params = array()) {
         return $this->initFax($id)->getFile()->retrieve($params);
     }
 
     public function listFaxes($params = array()) {
         return $this->faxes()->getList($params);
+    }
+
+    public function listATAs()
+    {
+        return $this->atas()->getList();
+    }
+
+    public function initATA($id) {
+        return $this->atas()->init($id);
+    }
+
+    public function retrieveATA($id)
+    {
+        return $this->initATA($id)->retrieve();
     }
 
     public function retrieveDefaultPhaxCode($getMetadata = false)

--- a/lib/Phaxio/ATA.php
+++ b/lib/Phaxio/ATA.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Phaxio;
+
+class ATA extends AbstractResource
+{
+    public static function init($phaxio, $id) {
+        return new self($phaxio, array('id' => $id));
+    }
+
+    public function retrieve() {
+        if (!isset($this->id)) throw new Exception("Must set ID before getting fax");
+
+        $result = $this->phaxio->doRequest("GET", 'atas/' . urlencode($this->id));
+        $this->exchangeArray($result->getData());
+
+        return $this;
+    }    
+}

--- a/lib/Phaxio/ATACollection.php
+++ b/lib/Phaxio/ATACollection.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Phaxio;
+
+class ATACollection extends AbstractResourceCollection
+{
+    protected $resource = 'atas';
+    protected $resource_class = 'ATA';
+}

--- a/lib/Phaxio/ATAs.php
+++ b/lib/Phaxio/ATAs.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Phaxio;
+
+class ATAs extends AbstractResources
+{
+    protected $collection_class = 'ATACollection';
+
+    public function init($id) {
+        return ATA::init($this->phaxio, $id);
+    }  
+}

--- a/lib/Phaxio/AbstractResourceCollection.php
+++ b/lib/Phaxio/AbstractResourceCollection.php
@@ -40,9 +40,9 @@ abstract class AbstractResourceCollection extends \ArrayObject
 
         foreach ($results->getData() as $result) {
             $resource_class = "Phaxio\\{$this->resource_class}";
-            $fax = new $resource_class($this->phaxio);
-            $fax->exchangeArray($result);
-            $this[] = $fax;
+            $arr = new $resource_class($this->phaxio);
+            $arr->exchangeArray($result);
+            $this[] = $arr;
         }
     }
 }


### PR DESCRIPTION
This PR is to address the issue of not having any functionality regarding ATAs. In this PR I've done a few things:

- add new `atas()` methods (list and retrieve) that can interact with the atas endpoint
- add example for listATAs
- rename variable in AbstractResourceCollection from `$fax` to `$arr` to make more sense with these changes
- fix spelling error in Phaxio.php `retrieveFaxFile` easy method.
- change private `$host` to match the new API version

Please let me know if you see issues with any of this and I will address them.

Thanks,
DC